### PR TITLE
feat: add output folder to workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,5 +59,8 @@ jspm_packages/
 .pnp.*
 
 # build
-./out
-./out/*
+out/
+
+# packages
+*.vsix
+move2kube-vscode-plugin-*.vsix

--- a/src/utilities/constants.ts
+++ b/src/utilities/constants.ts
@@ -2,3 +2,4 @@
 
 export const reponame = "konveyor/move2kube";
 export const cliName = "move2kube";
+export const pluginOutput = "m2kpluginoutput";

--- a/src/utilities/getHandlers.ts
+++ b/src/utilities/getHandlers.ts
@@ -2,10 +2,13 @@ import * as vscode from "vscode";
 import * as child_process from "child_process";
 import { getLatestVersionFromGithub } from "./checkCLI";
 import {
+  changeOutputLocation,
   getTerminalForDesktopCommands,
   getUserConfigOption,
   selectFolder,
+  showOutputFolderInWorkspace,
   showTimedInformationMessage,
+  updateVSCodeWorkspaceFolders,
 } from "./utils";
 
 let outputChannel: vscode.OutputChannel;
@@ -84,6 +87,13 @@ export async function createTransform(uri: vscode.Uri | undefined) {
       command += ` ${args.join(` `)}`;
     }
 
+    const outputPath = changeOutputLocation(terminal, cwd);
+    vscode.window.showInformationMessage(
+      `Move2Kube output will be generated in ${outputPath} location.`
+    );
+
+    await showOutputFolderInWorkspace(outputPath);
+
     terminal.show();
     terminal.sendText(command);
   } catch (err) {
@@ -112,6 +122,13 @@ export async function createCustomizationTransform(uri: vscode.Uri | undefined) 
     if (args.length > 0) {
       command += ` ${args.join(` `)}`;
     }
+
+    const outputPath = changeOutputLocation(terminal, cwd);
+    vscode.window.showInformationMessage(
+      `Move2Kube output will be generated in ${outputPath} location.`
+    );
+
+    await showOutputFolderInWorkspace(outputPath);
 
     terminal.show();
     terminal.sendText(command);


### PR DESCRIPTION
This commit will allow user to choose a quick pick option on transform and customizations to choose to add the output folder to workspace. For now, the output is stored in /home/swaingotnochill/.m2kplugi noutput/output directory. If a directory by name output is already present, the name is further modified as out - timestamp. This allows to store multiple outputs without bothering about overwrite flag or manually deleting it.