### PR TITLE
feat: add helm chart option and transform+all options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,39 @@
-# Move2Kube-VSCode-Extension
+<h1 align="center">
+  Move2Kube Extension for VS Code
+</h1>
 
-A VSCode extension for the Move2Kube application.
+The [Move2Kube](https://move2kube.konveyor.io/) extension helps developers accelerate the process of re-platforming to Kubernetes by analyzing source files.
 
-## Documentation
+## Installation
 
-For a deeper dive into how this works, read the guides below.
+Install the `move2kube` cli application in your machine first. This is a pre-requisite to run the extension.
 
-- [Extension structure](./docs/extension-structure.md)
-- [Extension commands](./docs/extension-commands.md)
-- [Extension development cycle](./docs/extension-development-cycle.md)
+Please visit the [Move2Kube Command Line Tool Installation](https://move2kube.konveyor.io/installation/cli) for step-by-step guide.
 
-## Run The Code
+`NOTE: Please make sure move2kube is added to the path. Without that, the extension will not work and throw error.`
 
-```bash
-# Navigate into project directory
-cd hello-world
+## Features
 
-# Install dependencies for both the extension and webview UI source code
-npm run install:all
+- Discover and create a plan file based on an input directory. (Work in progress)
+- Transform artifacts using move2kube plan.
 
-# Build webview UI source code
-npm run build:webview
+## Usage
 
-# Open sample in VS Code
-code .
-```
+- Right click on your folder where you would like to run `move2kube`.
+- Select your desired `move2kube` option.
+- The output will be generated in a `move2kubepluginoutput` folder which will be in the same level as the folder that was selected for the option.
 
-Once the code is open inside VS Code you can run the extension by doing the following:
+![Running `transform` command using m2k plugin](./assets/m2k-transform.gif)
 
-1. Press `F5` to open a new Extension Development Host window
-2. Inside the host window, open the command palette (`Ctrl+Shift+P` or `Cmd+Shift+P` on Mac) and type `Move2Kube: Hello`.
-3. For other implemented functions (suppose `plan`), open the command pallete and type `Move2Kube: Plan`.
-4. You can also run some functions on the context menu. Right click on the File Workspace and select the Move2Kube plan which is exposed to context menu.
+## References
 
-## Code of Conduct
-
-Refer to Konveyor's Code of Conduct [here](https://github.com/konveyor/community/blob/main/CODE_OF_CONDUCT.md).
+> [Installation](https://move2kube.konveyor.io/installation)
+<br>
+> [Tutorial](https://move2kube.konveyor.io/tutorials) 
+<br>
+> [Concepts](https://move2kube.konveyor.io/concepts) 
+<br>
+> [Transformers](https://move2kube.konveyor.io/transformers`)
+<br>
+> [Presentation](https://move2kube.konveyor.io/presentation)
+<br>

--- a/package.json
+++ b/package.json
@@ -4,14 +4,18 @@
   "description": "A VSCode extension for the Move2Kube application.",
   "version": "0.0.1",
   "engines": {
-    "vscode": "^1.46.0"
+    "vscode": "^1.76.0"
   },
   "categories": [
     "Other"
   ],
+  "preview": true,
   "activationEvents": [],
   "main": "./out/extension.js",
   "contributes": {
+    "workbench.colorCustomizations": {
+      "statusBar.background": "#008784"
+    },
     "commands": [
       {
         "command": "m2k.showHelloWorld",
@@ -26,12 +30,20 @@
         "title": "Move2Kube: Transform + Customizations"
       },
       {
+        "command": "m2k.transformAllOptions",
+        "title": "Move2Kube: Transform + All Options"
+      },
+      {
         "command": "m2k.plan",
         "title": "Move2Kube: Plan"
       },
       {
         "command": "m2k.checkForUpdates",
         "title": "Move2Kube: Check For Updates"
+      },
+      {
+        "command": "m2k.addHelmChart",
+        "title": "Move2Kube: Add helm chart"
       }
     ],
     "menus": {
@@ -50,6 +62,16 @@
           "when": "explorerResourceIsFolder",
           "command": "m2k.customizationTransform",
           "group": "move2kube@3"
+        },
+        {
+          "when": "explorerResourceIsFolder",
+          "command": "m2k.addHelmChart",
+          "group": "move2kube@4"
+        },
+        {
+          "when": "explorerResourceIsFolder",
+          "command": "m2k.transformAllOptions",
+          "group": "move2kube@5"
         }
       ]
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,10 +2,12 @@ import * as vscode from "vscode";
 import { HelloWorldPanel } from "./panels/HelloWorldPanel";
 import { isCLIInstalled } from "./utilities/checkCLI";
 import {
+  addHelmChartOption,
   checkForUpdates,
   createCustomizationTransform,
   createTransform,
   makePlan,
+  transformAllOptions,
 } from "./utilities/getHandlers";
 
 import { setOutputChannelForDesktopCommands } from "./utilities/utils";
@@ -46,10 +48,24 @@ export async function activate(context: vscode.ExtensionContext) {
     createCustomizationTransform
   );
 
+  // `transform` command with all options.
+  const allOptionsTransformCommand = vscode.commands.registerCommand(
+    "m2k.transformAllOptions",
+    transformAllOptions
+  );
+
+  // `addHelmChart` option.
+  const addHelmChartCommand = vscode.commands.registerCommand(
+    "m2k.addHelmChart",
+    addHelmChartOption
+  );
+
   // Add command to the extension context
   context.subscriptions.push(showHelloWorldCommand);
   context.subscriptions.push(transformCommand);
   context.subscriptions.push(customizationTransformCommand);
   context.subscriptions.push(planCommand);
+  context.subscriptions.push(allOptionsTransformCommand);
+  context.subscriptions.push(addHelmChartCommand);
   context.subscriptions.push(checkForUpdatesCommand);
 }

--- a/src/utilities/constants.ts
+++ b/src/utilities/constants.ts
@@ -3,3 +3,4 @@
 export const reponame = "konveyor/move2kube";
 export const cliName = "move2kube";
 export const pluginOutput = "m2kpluginoutput";
+export const defaultProjectName = "myproject";

--- a/src/utilities/getHandlers.ts
+++ b/src/utilities/getHandlers.ts
@@ -3,12 +3,21 @@ import * as child_process from "child_process";
 import { getLatestVersionFromGithub } from "./checkCLI";
 import {
   changeOutputLocation,
+  copyDirectory,
+  createTempDir,
+  getProjectName,
   getTerminalForDesktopCommands,
   getUserConfigOption,
+  posixToWindowsPath,
+  selectFile,
   selectFolder,
   showOutputFolderInWorkspace,
   showTimedInformationMessage,
+  showTimedStatusBarItem,
 } from "./utils";
+import path = require("path");
+import os = require("os");
+import { defaultProjectName, pluginOutput } from "./constants";
 
 let outputChannel: vscode.OutputChannel;
 
@@ -41,7 +50,7 @@ export async function checkForUpdates() {
 
 export async function makePlan(uri: vscode.Uri | undefined) {
   try {
-    showTimedInformationMessage(`Move2Kube: Running plan command...`, 3000);
+    showTimedStatusBarItem(`Move2Kube: Running plan command...`);
 
     const cwd =
       uri?.fsPath ||
@@ -72,7 +81,7 @@ export async function makePlan(uri: vscode.Uri | undefined) {
 
 export async function createTransform(uri: vscode.Uri | undefined) {
   try {
-    showTimedInformationMessage(`Move2Kube: Starting transform command...`, 3000);
+    showTimedStatusBarItem(`Move2Kube: Starting transform command...`);
     const terminal = getTerminalForDesktopCommands();
     const cwd =
       uri?.fsPath ||
@@ -82,10 +91,6 @@ export async function createTransform(uri: vscode.Uri | undefined) {
     let command = `move2kube transform -s ${cwd}`;
     const args = await getUserConfigOption();
 
-    if (args.length > 0) {
-      command += ` ${args.join(` `)}`;
-    }
-
     const outputPath = changeOutputLocation(terminal, cwd);
     vscode.window.showInformationMessage(
       `Move2Kube output will be generated in ${outputPath} location.`
@@ -94,6 +99,10 @@ export async function createTransform(uri: vscode.Uri | undefined) {
     const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(cwd));
     if (workspaceFolder && workspaceFolder.uri.fsPath === cwd) {
       await showOutputFolderInWorkspace(outputPath);
+    }
+
+    if (args.length > 0) {
+      command += ` ${args.join(` `)}`;
     }
 
     terminal.show();
@@ -106,10 +115,7 @@ export async function createTransform(uri: vscode.Uri | undefined) {
 
 export async function createCustomizationTransform(uri: vscode.Uri | undefined) {
   try {
-    showTimedInformationMessage(
-      `Move2Kube: Starting transform command with customizations...`,
-      3000
-    );
+    showTimedStatusBarItem(`Move2Kube: Starting transform command with customizations...`);
     const terminal = getTerminalForDesktopCommands();
     const cwd =
       uri?.fsPath ||
@@ -118,12 +124,17 @@ export async function createCustomizationTransform(uri: vscode.Uri | undefined) 
 
     const customizationFolder = await selectFolder("Select customization folder");
 
+    // If the user presses ESC key or does not select any folder, exit the process.
+    if (customizationFolder === undefined) {
+      vscode.window.showWarningMessage(
+        `Move2Kube will exit the transform process since customization folder is not selected.`
+      );
+      return;
+    }
+
     let command = `move2kube transform -s ${cwd} -c ${customizationFolder}`;
 
     const args = await getUserConfigOption();
-    if (args.length > 0) {
-      command += ` ${args.join(` `)}`;
-    }
 
     const outputPath = changeOutputLocation(terminal, cwd);
     vscode.window.showInformationMessage(
@@ -134,6 +145,129 @@ export async function createCustomizationTransform(uri: vscode.Uri | undefined) 
     if (workspaceFolder && workspaceFolder.uri.fsPath === cwd) {
       await showOutputFolderInWorkspace(outputPath);
     }
+
+    if (args.length > 0) {
+      command += ` ${args.join(` `)}`;
+    }
+
+    terminal.show();
+    terminal.sendText(command);
+  } catch (err) {
+    vscode.window.showErrorMessage(
+      `Failed to run transform with customizations.\n [ERROR] : ${err}`
+    );
+  }
+  return false;
+}
+
+export async function addHelmChartOption(uri: vscode.Uri | undefined) {
+  try {
+    showTimedStatusBarItem(`Move2Kube: Generating helm chart using transform...`);
+    const terminal = getTerminalForDesktopCommands();
+    const cwd =
+      uri?.fsPath ||
+      (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0].uri.fsPath) ||
+      process.cwd();
+
+    let command = `move2kube transform -s ${cwd}`;
+    const args = await getUserConfigOption();
+
+    // Create a temporary folder.
+    const tempDirUri = await createTempDir();
+    if (tempDirUri !== undefined) {
+      args.push("--output", tempDirUri.fsPath);
+    } else {
+      vscode.window.showErrorMessage(
+        `Error creating temporary directory which is necessary for running this move2kube option.`
+      );
+      return;
+    }
+
+    if (args.length > 0) {
+      command += ` ${args.join(` `)}`;
+    }
+    // Here, we are using temp folder as our directory where transformation will be generated.
+    terminal.show();
+    terminal.sendText(command, false);
+    terminal.sendText("; exit");
+
+    // For now its '/myproject'. Later change it with "project name" if you are allowing users to change the output folder name.
+    let helmChartPath = tempDirUri?.fsPath + "/myproject/deploy/yamls-parameterized/helm-chart";
+    if (os.platform() === "win32") {
+      helmChartPath = posixToWindowsPath(helmChartPath);
+    }
+
+    const disposeToken = vscode.window.onDidCloseTerminal(async (closedTerminal) => {
+      if (closedTerminal === terminal) {
+        disposeToken.dispose();
+        if (terminal.exitStatus !== undefined) {
+          await copyDirectory(
+            vscode.Uri.file(helmChartPath),
+            vscode.Uri.file(path.join(cwd, "..", pluginOutput, "helm-chart"))
+          );
+        } else {
+          vscode.window.showErrorMessage(`Terminal exited with undefined status.`);
+        }
+      }
+    });
+
+    // Delete the temporary folder.
+    await vscode.workspace.fs.delete(tempDirUri, { recursive: true, useTrash: false });
+  } catch (err) {
+    vscode.window.showErrorMessage(
+      `Failed to run transform with addHelmChartOption.\n [ERROR] : ${err}`
+    );
+  }
+}
+
+export async function transformAllOptions(uri: vscode.Uri | undefined) {
+  try {
+    showTimedStatusBarItem(`Move2Kube: Starting transform command with all options.`);
+    const terminal = getTerminalForDesktopCommands();
+    const cwd =
+      uri?.fsPath ||
+      (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0].uri.fsPath) ||
+      process.cwd();
+
+    let command = `move2kube transform -s ${cwd}`;
+
+    // TODO: Refactor this. It somehow feels weird to start with getUserConfigOption every time.
+    const args = await getUserConfigOption();
+
+    const projectName = await getProjectName();
+    if (projectName !== defaultProjectName) {
+      args.push("--name", projectName);
+    }
+
+    const planPath = await selectFile(`Specify a plan to to execute. (default "m2k.plan")`);
+    if (planPath !== undefined) {
+      args.push("--plan", planPath);
+    }
+
+    const transformSelector = await selectFile(`Specify the transform selector.`);
+    if (transformSelector !== undefined) {
+      args.push("--transformer-selector", transformSelector);
+    }
+
+    let outputDirectory = await selectFolder(
+      "Path for Output. Default will be directory with project name."
+    );
+
+    if (outputDirectory === undefined) {
+      outputDirectory = cwd;
+    }
+
+    let outputPath = changeOutputLocation(terminal, outputDirectory);
+    vscode.window.showInformationMessage(outputPath);
+    await showOutputFolderInWorkspace(outputPath);
+
+    if (args.length > 0) {
+      command += ` ${args.join(` `)}`;
+    }
+
+    vscode.window.showInformationMessage(
+      `Move2Kube output will be generated in ${outputDirectory} location.`
+    );
 
     terminal.show();
     terminal.sendText(command);


### PR DESCRIPTION
It adds an helm chart option by generating the transform output in a temp directory and then copying the helm chart folder to the required location.

It adds transform command with few more flags like plan, transform selector.