### PR TITLE
fix: helm-chart now generates inside src folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,17 @@
   "displayName": "m2k",
   "description": "A VSCode extension for the Move2Kube application.",
   "version": "0.0.1",
+  "publisher": "Konveyor",
   "engines": {
     "vscode": "^1.76.0"
   },
   "categories": [
     "Other"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/konveyor/move2kube-vscode-plugin"
+  },
   "preview": true,
   "activationEvents": [],
   "main": "./out/extension.js",
@@ -23,7 +28,7 @@
       },
       {
         "command": "m2k.transform",
-        "title": "Move2Kube: Transform"
+        "title": "Move2Kube: Simple Transform"
       },
       {
         "command": "m2k.customizationTransform",
@@ -55,26 +60,35 @@
         },
         {
           "when": "explorerResourceIsFolder",
-          "command": "m2k.transform",
+          "command": "m2k.addHelmChart",
           "group": "move2kube@2"
         },
         {
-          "when": "explorerResourceIsFolder",
-          "command": "m2k.customizationTransform",
+          "submenu": "transform",
           "group": "move2kube@3"
+        }
+      ],
+      "transform": [
+        {
+          "command": "m2k.transform",
+          "group": "move2kube@3@1"
         },
         {
-          "when": "explorerResourceIsFolder",
-          "command": "m2k.addHelmChart",
-          "group": "move2kube@4"
+          "command": "m2k.customizationTransform",
+          "group": "move2kube@3@2"
         },
         {
-          "when": "explorerResourceIsFolder",
           "command": "m2k.transformAllOptions",
-          "group": "move2kube@5"
+          "group": "move2kube@3@3"
         }
       ]
-    }
+    },
+    "submenus": [
+      {
+        "label": "Move2Kube: Run Transform",
+        "id": "transform"
+      }
+    ]
   },
   "scripts": {
     "install:all": "npm install && cd webview-ui && npm install",

--- a/src/utilities/constants.ts
+++ b/src/utilities/constants.ts
@@ -2,5 +2,5 @@
 
 export const reponame = "konveyor/move2kube";
 export const cliName = "move2kube";
-export const pluginOutput = "m2kpluginoutput";
+export const pluginOutput = "m2koutput";
 export const defaultProjectName = "myproject";

--- a/src/utilities/utils.ts
+++ b/src/utilities/utils.ts
@@ -158,9 +158,13 @@ Terminal: vscode.Terminal is used for creating and moving between directories.
 cwd: The source folder on which "transform" or other command is clicked. It is needed as the output folder should be
 generated in the same level as source.
 */
-export function changeOutputLocation(terminal: vscode.Terminal, cwd: string): string {
-  // All generated output is stored in a folder name m2kpluginoutput.
-  const outputFolder = path.join(cwd, "..", pluginOutput);
+export function changeOutputLocation(
+  terminal: vscode.Terminal,
+  cwd: string,
+  projectName: string = defaultProjectName
+): string {
+  // All generated output is stored in a folder name defined by variable `pluginOutput/projectName`.
+  const outputFolder = path.join(cwd, "..", pluginOutput, projectName);
 
   const mkdirCommand =
     os.platform() === "win32"


### PR DESCRIPTION
This PR brings following changes:
- Change the ldestination location of helm-chart to inside source folder. 
- Rename global constant plugin output. 
- The output gets generated inside pluginoutput/projectName now instead of just pluginOutput.